### PR TITLE
Added type annotations for everything

### DIFF
--- a/Channel/SerializedChannelFactory.php
+++ b/Channel/SerializedChannelFactory.php
@@ -16,6 +16,9 @@ final class SerializedChannelFactory implements ChannelFactoryInterface
     {
     }
 
+    /**
+     * @return self
+     */
     public static function getInstance()
     {
         if (!self::$instance) {

--- a/Reader/CDataReader.php
+++ b/Reader/CDataReader.php
@@ -11,6 +11,9 @@ use EXSyst\Component\IO\Source\StringSource;
 
 class CDataReader extends OuterSource
 {
+    /**
+     * @var string
+     */
     const WHITE_SPACE_MASK = "\011\n\013\014\r ";
 
     /**

--- a/Reader/JsonReader.php
+++ b/Reader/JsonReader.php
@@ -22,7 +22,7 @@ class JsonReader extends OuterSource
      * @param int  $depth
      * @param int  $options
      *
-     * @return string|null
+     * @return mixed
      *
      * @throws Exception\UnderflowException when the source is not enough longuer to fulfill the request
      * @throws Exception\RuntimeException   when the JSON is invalid or too deeply nested
@@ -45,7 +45,7 @@ class JsonReader extends OuterSource
      * @param int  $depth
      * @param bool $inner
      *
-     * @return string|null
+     * @return string
      *
      * @throws Exception\UnderflowException when the source is not enough longuer to fulfill the request
      * @throws Exception\RuntimeException   when the JSON is invalid or too deeply nested

--- a/Selectable.php
+++ b/Selectable.php
@@ -62,6 +62,13 @@ class Selectable implements SelectableInterface
         }
     }
 
+    /**
+     * @param array $objects
+     * @param array $objectsByStream
+     * @param array $streams
+     *
+     * @throws Exception\InvalidArgumentException
+     */
     private static function preprocessSet(array &$objects, array &$objectsByStream, array &$streams)
     {
         foreach ($objects as $object) {

--- a/Sink.php
+++ b/Sink.php
@@ -6,7 +6,6 @@ use EXSyst\Component\IO\Sink\SinkInterface;
 use EXSyst\Component\IO\Sink\RecordFunctionSink;
 use EXSyst\Component\IO\Sink\SystemSink;
 use EXSyst\Component\IO\Source\StreamSource;
-use EXSyst\Component\IO\Source\BufferedSource;
 
 final class Sink
 {
@@ -31,7 +30,7 @@ final class Sink
      * @param string        $mode
      * @param callable|null $onClose
      *
-     * @return StreamSource|BufferedSource
+     * @return StreamSource
      */
     public static function fromFile($file, $mode = 'wb', $onClose = null)
     {
@@ -39,7 +38,7 @@ final class Sink
     }
 
     /**
-     * @return SystemSink
+     * @return SinkInterface
      */
     public static function fromOutput()
     {
@@ -47,7 +46,7 @@ final class Sink
     }
 
     /**
-     * @return StreamSource
+     * @return SinkInterface
      */
     public static function fromError()
     {
@@ -59,7 +58,7 @@ final class Sink
      * @param string|null $destination
      * @param string|null $extraHeaders
      *
-     * @return RecordFunctionSink
+     * @return SinkInterface
      */
     public static function fromLog($messageType = 0, $destination = null, $extraHeaders = null)
     {
@@ -94,7 +93,7 @@ final class Sink
      * @param string        $format
      * @param mixed         $arg,...
      */
-    public static function writeFormatted(SinkInterface $sink, $format)
+    public static function writeFormatted(SinkInterface $sink, $format/*, ...$arg */)
     {
         $args = array_slice(func_get_args(), 2);
         if ($sink instanceof SystemSink) {

--- a/Sink/StringSink.php
+++ b/Sink/StringSink.php
@@ -4,6 +4,9 @@ namespace EXSyst\Component\IO\Sink;
 
 class StringSink implements SinkInterface
 {
+    /**
+     * @var int
+     */
     const MAX_CONCAT_LENGTH = 4096;
 
     /**
@@ -63,6 +66,9 @@ class StringSink implements SinkInterface
         return $this;
     }
 
+    /**
+     * @return string This object's string representation
+     */
     public function __toString()
     {
         return implode($this->data);

--- a/Sink/SystemSink.php
+++ b/Sink/SystemSink.php
@@ -4,6 +4,9 @@ namespace EXSyst\Component\IO\Sink;
 
 final class SystemSink implements SinkInterface
 {
+    /**
+     * @var int
+     */
     const BLOCK_BYTE_COUNT = 1024;
 
     /**
@@ -21,6 +24,9 @@ final class SystemSink implements SinkInterface
         $this->written = 0;
     }
 
+    /**
+     * @return self
+     */
     public static function getInstance()
     {
         if (!self::$instance) {

--- a/Source.php
+++ b/Source.php
@@ -11,7 +11,13 @@ use EXSyst\Component\IO\Source\StringSource;
 
 final class Source
 {
+    /**
+     * @var int
+     */
     const MIN_BLOCK_BYTE_COUNT = 4096;
+    /**
+     * @var int
+     */
     const MIN_SPAN_BLOCK_BYTE_COUNT = 128;
 
     private function __construct()
@@ -81,7 +87,7 @@ final class Source
     }
 
     /**
-     * @return StreamSource|BufferedSource
+     * @return SourceInterface
      */
     public static function fromInput()
     {

--- a/Source/BufferedSource.php
+++ b/Source/BufferedSource.php
@@ -82,7 +82,7 @@ class BufferedSource extends OuterSource
      * @param BufferedSourceBuffer $firstBuffer
      * @param int                  $cursor
      *
-     * @return string|bool
+     * @return false|string
      */
     private static function readFromSingleBuffer(&$byteCount, BufferedSourceBuffer &$firstBuffer, &$cursor)
     {
@@ -107,9 +107,9 @@ class BufferedSource extends OuterSource
     }
 
     /**
-     * @var int
-     * @var BufferedSourceBuffer
-     * @var int
+     * @param int                  $byteCount
+     * @param BufferedSourceBuffer $firstBuffer
+     * @param int                  $cursor
      *
      * @return string
      */

--- a/Source/BufferedSource.php
+++ b/Source/BufferedSource.php
@@ -10,9 +10,21 @@ use EXSyst\Component\IO\Sink\StringSink;
 
 class BufferedSource extends OuterSource
 {
+    /**
+     * @var BufferedSourceBuffer
+     */
     private $firstBuffer;
+    /**
+     * @var BufferedSourceBuffer
+     */
     private $lastBuffer;
+    /**
+     * @var int
+     */
     private $cursor;
+    /**
+     * @var int
+     */
     private $stateCount;
 
     /**
@@ -64,6 +76,14 @@ class BufferedSource extends OuterSource
 
         return true;
     }
+
+    /**
+     * @param int                  $byteCount
+     * @param BufferedSourceBuffer $firstBuffer
+     * @param int                  $cursor
+     *
+     * @return string|bool
+     */
     private static function readFromSingleBuffer(&$byteCount, BufferedSourceBuffer &$firstBuffer, &$cursor)
     {
         if ($cursor == $firstBuffer->length) {
@@ -85,6 +105,14 @@ class BufferedSource extends OuterSource
 
         return $data;
     }
+
+    /**
+     * @var int
+     * @var BufferedSourceBuffer
+     * @var int
+     *
+     * @return string
+     */
     private static function readFromBuffers($byteCount, BufferedSourceBuffer &$firstBuffer, &$cursor)
     {
         $accumulator = [];
@@ -99,6 +127,12 @@ class BufferedSource extends OuterSource
         return implode($accumulator);
     }
 
+    /**
+     * @param int $byteCount
+     * @param int $minByteCount
+     *
+     * @return bool
+     */
     private function ensureVirtualBufferByteCount($byteCount, $minByteCount)
     {
         while (($bufsize = $this->getVirtualBufferByteCount()) < $byteCount) {
@@ -110,6 +144,12 @@ class BufferedSource extends OuterSource
         return true;
     }
 
+    /**
+     * @param int  $byteCount
+     * @param bool $allowIncomplete
+     *
+     * @return bool
+     */
     private function ensureRemainingBufferByteCount($byteCount, $allowIncomplete)
     {
         $cursor = $this->getConsumedByteCount();
@@ -123,11 +163,17 @@ class BufferedSource extends OuterSource
         return $this->firstBuffer->offset + $this->cursor;
     }
 
+    /**
+     * @return int
+     */
     private function getVirtualBufferByteCount()
     {
         return $this->lastBuffer->offset + $this->lastBuffer->length;
     }
 
+    /**
+     * @return int
+     */
     private function getRemainingBufferByteCount()
     {
         return $this->getVirtualBufferByteCount() - $this->getConsumedByteCount();
@@ -183,6 +229,14 @@ class BufferedSource extends OuterSource
         return new BufferedSourceState($this->firstBuffer, $this->cursor, $this->stateCount);
     }
 
+    /**
+     * @param int  $byteCount
+     * @param bool $allowIncomplete
+     * @param bool $skipping
+     *
+     * @throws Exception\LengthException
+     * @throws Exception\UnderflowException
+     */
     private function checkByteCount(&$byteCount, $allowIncomplete, $skipping)
     {
         if ($byteCount < 0) {

--- a/Source/Internal/BufferedSourceBuffer.php
+++ b/Source/Internal/BufferedSourceBuffer.php
@@ -11,9 +11,21 @@ namespace EXSyst\Component\IO\Source\Internal;
  */
 class BufferedSourceBuffer
 {
+    /**
+     * @var int
+     */
     public $offset = 0;
+    /**
+     * @var string
+     */
     public $data = '';
+    /**
+     * @var int
+     */
     public $length = 0;
+    /**
+     * @var self|null
+     */
     public $next = null;
 
     /**

--- a/Source/Internal/BufferedSourceState.php
+++ b/Source/Internal/BufferedSourceState.php
@@ -14,10 +14,25 @@ use EXSyst\Component\IO\StateInterface;
  */
 class BufferedSourceState implements StateInterface
 {
+    /**
+     * @var BufferedSourceBuffer
+     */
     private $firstBufferRef;
+    /**
+     * @var BufferedSourceBuffer
+     */
     private $firstBuffer;
+    /**
+     * @var int
+     */
     private $cursorRef;
+    /**
+     * @var int
+     */
     private $cursor;
+    /**
+     * @var int
+     */
     private $stateCountRef;
 
     /**

--- a/Source/Internal/StreamSourceState.php
+++ b/Source/Internal/StreamSourceState.php
@@ -14,7 +14,13 @@ use EXSyst\Component\IO\StateInterface;
  */
 class StreamSourceState implements StateInterface
 {
+    /**
+     * @var resource
+     */
     private $stream;
+    /**
+     * @var int
+     */
     private $cursor;
 
     /**

--- a/Source/Internal/StringSourceState.php
+++ b/Source/Internal/StringSourceState.php
@@ -14,7 +14,13 @@ use EXSyst\Component\IO\StateInterface;
  */
 class StringSourceState implements StateInterface
 {
+    /**
+     * @var int
+     */
     private $offsetRef;
+    /**
+     * @var int
+     */
     private $offset;
 
     /**

--- a/Source/StreamSource.php
+++ b/Source/StreamSource.php
@@ -125,6 +125,9 @@ class StreamSource implements SelectableInterface, SinkInterface, SourceInterfac
         return $this->getConsumedByteCount();
     }
 
+    /**
+     * @return bool
+     */
     private function selectRead()
     {
         $read = [$this->stream];
@@ -192,6 +195,12 @@ class StreamSource implements SelectableInterface, SinkInterface, SourceInterfac
         return new StreamSourceState($this->stream);
     }
 
+    /**
+     * @param int $byteCount
+     * @param bool $allowIncomplete
+     *
+     * @return bool
+     */
     private function checkByteCount(&$byteCount, $allowIncomplete)
     {
         if ($byteCount < 0) {


### PR DESCRIPTION
Type annotations should be present on every variable, constant and method, to ease static analysis and reading, even if there is no full documentation at the moment.
